### PR TITLE
Suffix POM version with '-shared-inventory' for fork

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory</artifactId>
   <groupId>org.folio</groupId>
-  <version>14.0.0-SNAPSHOT</version>
+  <version>14.0.0-shared-inventory</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>


### PR DESCRIPTION
   To distinguish versions of the "shared-inventory" fork
   of mod-inventory from versions of the original project,
   we are suffixing the version numbers with
   '-shared-inventory[.sequence-number]